### PR TITLE
Fix for #124

### DIFF
--- a/bleach/__init__.py
+++ b/bleach/__init__.py
@@ -256,6 +256,7 @@ def linkify(text, callbacks=DEFAULT_CALLBACKS, skip_pre=False,
                         # Insert the new nodes made from my tail into
                         # the tree right after me. current_child+1
                         children += adj
+                        continue
 
                 new_tail = re.sub(url_re, link_repl, new_tail)
                 if new_tail != old_tail:

--- a/bleach/tests/test_links.py
+++ b/bleach/tests/test_links.py
@@ -81,6 +81,10 @@ def test_email_link():
          'james@example.com</a>',
          True,
          'email to <a href="james@example.com">james@example.com</a>'),
+        ('<br><a href="mailto:jinkyun@example.com">'
+         'jinkyun@example.com</a>',
+         True,
+         '<br>jinkyun@example.com'),
     )
 
     def _check(o, p, i):


### PR DESCRIPTION
There is a bug with email parsing #124.
This happens when html element which is direct parent of email string has child tag inside.
Example:
```
<p><span>foo</span>example@gmail.com</p>
<p>qwer<br />example@gmail.com</p>
<br />example@gmail.com
```
Those 3 above hangs when calling `linkfiy` with `parse_email=True`
It is because `link_repl` is called after `email_repl`, making part of email address(`gmail.com`) to an anchor tag again.

At line 236, in the middle of lines that process `node.text`, that kind of unwanted recursion was taken care of, but for `node.tail`, it wasn't.
So I added a `continue` in the middle of lines that process `node.tail`.

Now it doesn't hang, perfectly showing beautiful links.